### PR TITLE
Bring back bounding boxes

### DIFF
--- a/msg/Detection2D.msg
+++ b/msg/Detection2D.msg
@@ -10,6 +10,7 @@ Header header
 vision_msgs/ObjectHypothesis2D[] results
 
 # 2D bounding box surrounding the object.
+BoundingBox2D bbox
 
 # The 2D data that generated these results (i.e. region proposal cropped out of
 # the image). Not required for all use cases, so it may be empty.

--- a/msg/Detection3D.msg
+++ b/msg/Detection3D.msg
@@ -10,6 +10,9 @@ Header header
 # object ids, the scores for any ids not listed are assumed to be 0.
 vision_msgs/ObjectHypothesis3D[] results
 
+# 3D bounding box surrounding the object.
+BoundingBox3D bbox
+
 # The 3D data that generated these results (i.e. region proposal cropped out of
 # the image). Not required for all detectors, so it may be empty.
 sensor_msgs/PointCloud2 source_cloud


### PR DESCRIPTION
These somehow got lost underway; the BoundingBoxXD message definitions are still
there, but were not included in the DetectionXD messages.