### PR TITLE
[WIP] simpler BoundingBox2D

### DIFF
--- a/msg/BoundingBox2D.msg
+++ b/msg/BoundingBox2D.msg
@@ -1,9 +1,9 @@
 # Note: This message plans to move to geometry_msgs in the final implementation.
 
-# The 2D position (in pixels) and orientation of the bounding box origin.
-geometry_msgs/Pose2D origin
+# The 2D position (in pixels) and orientation of the bounding box center.
+geometry_msgs/Pose2D center
 
 # The size (in pixels) of the bounding box surrounding the object relative 
-# to the pose of its origin
+# to the pose of its center
 uint32 size_x
 uint32 size_y

--- a/msg/BoundingBox2D.msg
+++ b/msg/BoundingBox2D.msg
@@ -1,4 +1,5 @@
-# Note: This message plans to move to geometry_msgs in the final implementation.
+# Note: This message *DOES NOT* plan to move to geometry_msgs in the final
+# implementation, because it uses pixels, not meters.
 
 # The 2D position (in pixels) and orientation of the bounding box center.
 geometry_msgs/Pose2D center

--- a/msg/BoundingBox2D.msg
+++ b/msg/BoundingBox2D.msg
@@ -5,5 +5,5 @@ geometry_msgs/Pose2D center
 
 # The size (in pixels) of the bounding box surrounding the object relative 
 # to the pose of its center
-uint32 size_x
-uint32 size_y
+float size_x
+float size_y

--- a/msg/BoundingBox3D.msg
+++ b/msg/BoundingBox3D.msg
@@ -1,8 +1,8 @@
 # Note: This message plans to move to geometry_msgs in the final implementation.
 
-# The 3D position and orientation of the bounding box origin
-geometry_msgs/Pose origin
+# The 3D position and orientation of the bounding box center
+geometry_msgs/Pose center
 
 # The size of the bounding box surrounding the object relative to the pose of 
-# its origin
+# its center
 geometry_msgs/Vector3 size

--- a/msg/Detection2D.msg
+++ b/msg/Detection2D.msg
@@ -10,7 +10,7 @@ Header header
 vision_msgs/ObjectHypothesisWithPose[] results
 
 # 2D bounding box surrounding the object.
-BoundingBox2D bbox
+sensor_msgs/RegionOfInterest bbox
 
 # The 2D data that generated these results (i.e. region proposal cropped out of
 # the image). Not required for all use cases, so it may be empty.


### PR DESCRIPTION
This PR is to continue the discussion from #2 about bounding boxes.

I would strongly prefer to use something like a [`sensor_msgs/RegionOfInterest`](http://docs.ros.org/lunar/api/sensor_msgs/html/msg/RegionOfInterest.html) for the 2D bounding box:

* no rotation
* pixel coordinates (`uint32`) specify the top left corner and the size in x and y.

This would be much easier to implement correctly than a rotated bounding box with floats. With that approach, we would have to specify things like "use the Bresenham algorithm to figure out which pixels are inside the rotated box". I'm afraid since most people don't use the rotation, they'd just ignore it or implement it incorrectly.

Unfortunately, `sensor_msgs/RegionOfInterest` has a weird `do_rectify` field which doesn't make sense here. If that's a show stopper, we should create our own copy of RegionOfInterest without that field, otherwise we can use RegionOfInterest directly.

----------------------------------------------------------------------

If we *do* use the current BoundingBox2D, it should use `float` everywhere; as agreed upon in #2, it doesn't make sense to specify the center in `float` and the size in `uint32`.

If that message moves to `geometry_msgs`, it shouldn't be in pixel coordinates, but in meters. All the other measures of length in that package are in meters, and assume that some people would want to use `geometry_msgs/BoundingBox2D` for stuff like specifying a rectangular region in a map (where meters is the obvious unit). But meters would be useless for us. All this leads me to believe that a BoundingBox2D that would live happily in `geometry_msgs` is different from what we need.

Note that this doesn't apply to `BoundingBox3D`: It's already in meters, so it could go to `geometry_msgs`.