### PR TITLE
Add headers to the *Array messages

### DIFF
--- a/msg/Detection2DArray.msg
+++ b/msg/Detection2DArray.msg
@@ -1,5 +1,7 @@
 # A list of 2D detections, for a multi-object 2D detector.
 
+Header header
+
 # A list of the detected proposals. A multi-proposal detector might generate
 #   this list with many candidate detections generated from a single input.
 Detection2D[] detections

--- a/msg/Detection3DArray.msg
+++ b/msg/Detection3DArray.msg
@@ -1,5 +1,7 @@
 # A list of 3D detections, for a multi-object 3D detector.
 
+Header header
+
 # A list of the detected proposals. A multi-proposal detector might generate
 #   this list with many candidate detections generated from a single input.
 Detection3D[] detections


### PR DESCRIPTION
The primary motivation for doing this is to enable display of the *Array messages directly in RViz, which requires messages to have headers.

Although this could mean a 3-layer nesting of messages with `Header`s, this is a standard ROS paradigm.