### PR TITLE
Avoid CMP0048 warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(vision_msgs)
 
 find_package(catkin REQUIRED COMPONENTS


### PR DESCRIPTION
Examples of similar fixes:
https://github.com/ros/catkin/pull/1052
https://github.com/ros/message_generation/pull/5