### PR TITLE
Clarify: ObjectHypothesis[] ~= Classification

### DIFF
--- a/msg/ObjectHypothesis.msg
+++ b/msg/ObjectHypothesis.msg
@@ -1,4 +1,6 @@
 # An object hypothesis that contains no pose information.
+# If you would like to define an array of ObjectHypothesis messages,
+#   please see the Classification2D or Classification3D message types.
 
 # The unique ID of the object class. To get additional information about
 #   this ID, such as its human-readable class name, listeners should perform a

--- a/msg/ObjectHypothesisWithPose.msg
+++ b/msg/ObjectHypothesisWithPose.msg
@@ -1,4 +1,6 @@
 # An object hypothesis that contains pose information.
+# If you would like to define an array of ObjectHypothesisWithPose messages,
+#   please see the Detection2D or Detection3D message types.
 
 # The object hypothesis (ID and score).
 ObjectHypothesis hypothesis


### PR DESCRIPTION
https://github.com/ros-perception/vision_msgs/issues/46 requested Array message types for ObjectHypothesis and/or ObjectHypothesisWithPose. As pointed out in the issue, these already exist in the form of the `ClassificationXD` and `DetectionXD` message types.

Closes #46