### PR TITLE
Remove is_tracking field

### DIFF
--- a/msg/Detection2D.msg
+++ b/msg/Detection2D.msg
@@ -18,5 +18,4 @@ sensor_msgs/Image source_img
 
 # ID used for consistency across multiple detection messages. This value will
 #   likely differ from the id field set in each individual ObjectHypothesis.
-# If you set this field, be sure to also set is_tracking to True.
 string tracking_id

--- a/msg/Detection2D.msg
+++ b/msg/Detection2D.msg
@@ -16,9 +16,6 @@ BoundingBox2D bbox
 #   the image). Not required for all use cases, so it may be empty.
 sensor_msgs/Image source_img
 
-# If true, this message contains object tracking information.
-bool is_tracking
-
 # ID used for consistency across multiple detection messages. This value will
 #   likely differ from the id field set in each individual ObjectHypothesis.
 # If you set this field, be sure to also set is_tracking to True.

--- a/msg/Detection3D.msg
+++ b/msg/Detection3D.msg
@@ -20,5 +20,4 @@ sensor_msgs/PointCloud2 source_cloud
 
 # ID used for consistency across multiple detection messages. This value will
 #   likely differ from the id field set in each individual ObjectHypothesis.
-# If you set this field, be sure to also set is_tracking to True.
 string tracking_id

--- a/msg/Detection3D.msg
+++ b/msg/Detection3D.msg
@@ -18,9 +18,6 @@ BoundingBox3D bbox
 #   be empty.
 sensor_msgs/PointCloud2 source_cloud
 
-# If this message was tracking result, this field set true.
-bool is_tracking
-
 # ID used for consistency across multiple detection messages. This value will
 #   likely differ from the id field set in each individual ObjectHypothesis.
 # If you set this field, be sure to also set is_tracking to True.


### PR DESCRIPTION
This field does not seem useful, and we are not aware of anyone using it at this time. `VisionInfo` is probably a better place for this information anyway, if it were needed. 

See #47 for earlier discussions.