### PR TITLE
Bring noetic-devel branch back to compatibility with 0.0.1 tag

### DIFF
--- a/msg/Detection2D.msg
+++ b/msg/Detection2D.msg
@@ -15,11 +15,3 @@ BoundingBox2D bbox
 # The 2D data that generated these results (i.e. region proposal cropped out of
 #   the image). Not required for all use cases, so it may be empty.
 sensor_msgs/Image source_img
-
-# If true, this message contains object tracking information.
-bool is_tracking
-
-# ID used for consistency across multiple detection messages. This value will
-#   likely differ from the id field set in each individual ObjectHypothesis.
-# If you set this field, be sure to also set is_tracking to True.
-string tracking_id

--- a/msg/Detection3D.msg
+++ b/msg/Detection3D.msg
@@ -17,11 +17,3 @@ BoundingBox3D bbox
 #   the image). This information is not required for all detectors, so it may
 #   be empty.
 sensor_msgs/PointCloud2 source_cloud
-
-# If this message was tracking result, this field set true.
-bool is_tracking
-
-# ID used for consistency across multiple detection messages. This value will
-#   likely differ from the id field set in each individual ObjectHypothesis.
-# If you set this field, be sure to also set is_tracking to True.
-string tracking_id

--- a/msg/ObjectHypothesis.msg
+++ b/msg/ObjectHypothesis.msg
@@ -1,9 +1,9 @@
 # An object hypothesis that contains no position information.
 
-# The unique ID of the object class. To get additional information about
-#   this ID, such as its human-readable class name, listeners should perform a
-#   lookup in a metadata database. See vision_msgs/VisionInfo.msg for more detail.
-string id
+# The unique numeric ID of object detected. To get additional information about
+#   this ID, such as its human-readable name, listeners should perform a lookup
+#   in a metadata database. See vision_msgs/VisionInfo.msg for more detail.
+int64 id
 
 # The probability or confidence value of the detected object. By convention,
 #   this value should lie in the range [0-1].

--- a/msg/ObjectHypothesisWithPose.msg
+++ b/msg/ObjectHypothesisWithPose.msg
@@ -1,9 +1,9 @@
 # An object hypothesis that contains position information.
 
-# The unique ID of the object class. To get additional information about
+# The unique numeric ID of the object class. To get additional information about
 #   this ID, such as its human-readable class name, listeners should perform a
 #   lookup in a metadata database. See vision_msgs/VisionInfo.msg for more detail.
-string id
+int64 id
 
 # The probability or confidence value of the detected object. By convention,
 #   this value should lie in the range [0-1].

--- a/msg/VisionInfo.msg
+++ b/msg/VisionInfo.msg
@@ -19,8 +19,8 @@ string method
 # Location where the metadata database is stored. The recommended location is
 #   as an XML string on the ROS parameter server, but the exact implementation
 #   and information is left up to the user.
-# The database should store information attached to class ids. Each
-#   class id should map to an atomic, visually recognizable element. This
+# The database should store information attached to numeric ids. Each
+#   numeric id should map to an atomic, visually recognizable element. This
 #   definition is intentionally vague to allow extreme flexibility. The
 #   elements could be classes in a pixel segmentation algorithm, object classes
 #   in a detector, different people's faces in a face detection algorithm, etc.


### PR DESCRIPTION
Closes #56 

Reverting breaking changes that were merged into `noetic-devel` after 0.0.1 release.

Check changes with `git diff 0.0.1 kukanani/0.0.1-noetic-feature-parity`. All changes from 0.0.1 are in CMakeLists.txt, package.xml, comments/whitespace (don't affect md5sum), and the addition of `BoundingBox3DArray`.