### PR TITLE
std::basic_ostream<char>’ has no member named ‘str’

### DIFF
--- a/vision_msgs_rviz_plugins/include/vision_msgs_rviz_plugins/detection_3d_common.hpp
+++ b/vision_msgs_rviz_plugins/include/vision_msgs_rviz_plugins/detection_3d_common.hpp
@@ -447,7 +447,11 @@ protected:
     marker->type = Marker::TEXT_VIEW_FACING;
     marker->action = Marker::ADD;
     marker->header = detection.header;
-    marker->text = (std::ostringstream{} << std::fixed << std::setprecision(2) << score).str();
+    std::ostringstream oss;
+    oss << std::fixed;
+    oss << std::setprecision(2);
+    oss << score;
+    marker->text = oss.str();
     marker->scale.z = 0.5;         // Set the size of the text
     marker->id = idx;
     marker->ns = "score";


### PR DESCRIPTION
Fix https://github.com/ros-perception/vision_msgs/issues/80
I haven't tested it runtime though but this shall work