### PR TITLE
Revert "std::basic_ostream<char>’ has no member named ‘str’"

### DIFF
--- a/vision_msgs_rviz_plugins/include/vision_msgs_rviz_plugins/detection_3d_common.hpp
+++ b/vision_msgs_rviz_plugins/include/vision_msgs_rviz_plugins/detection_3d_common.hpp
@@ -447,11 +447,7 @@ protected:
     marker->type = Marker::TEXT_VIEW_FACING;
     marker->action = Marker::ADD;
     marker->header = detection.header;
-    std::ostringstream oss;
-    oss << std::fixed;
-    oss << std::setprecision(2);
-    oss << score;
-    marker->text = oss.str();
+    marker->text = (std::ostringstream{} << std::fixed << std::setprecision(2) << score).str();
     marker->scale.z = 0.5;         // Set the size of the text
     marker->id = idx;
     marker->ns = "score";


### PR DESCRIPTION
Reverts ros-perception/vision_msgs#81 @gorghino

This does not compile https://build.ros2.org/job/Fdev__vision_msgs__ubuntu_focal_amd64/16/