### PR TITLE
Fix for error: ‘rcpputils::fs’ has not been declared and QT MOC header

### DIFF
--- a/vision_msgs_rviz_plugins/CMakeLists.txt
+++ b/vision_msgs_rviz_plugins/CMakeLists.txt
@@ -22,6 +22,7 @@ find_package(yaml_cpp_vendor REQUIRED)
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_python REQUIRED)
 
+find_package(rcpputils)
 find_package(rclcpp REQUIRED)
 find_package(rclpy REQUIRED)
 
@@ -31,16 +32,15 @@ find_package(rviz_default_plugins REQUIRED)
 find_package(rviz_rendering REQUIRED)
 find_package(vision_msgs REQUIRED)
 
+
 ## This setting causes Qt's "MOC" generation to happen automatically, which is required for
 ## Qt's signal/slot connections to work.
 set(CMAKE_AUTOMOC ON)
 
 
 set(vision_msgs_rviz_plugins_headers_to_moc
-  include/vision_msgs_rviz_plugins/detection_3d_common.hpp
   include/vision_msgs_rviz_plugins/detection_3d_array.hpp
   include/vision_msgs_rviz_plugins/detection_3d.hpp
-  include/vision_msgs_rviz_plugins/bounding_box_3d_common.hpp
   include/vision_msgs_rviz_plugins/bounding_box_3d.hpp
   include/vision_msgs_rviz_plugins/bounding_box_3d_array.hpp
 )
@@ -84,6 +84,7 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE "RVIZ_DEFAULT_PLUGINS_BUILDIN
 
 ament_target_dependencies(${PROJECT_NAME}
   PUBLIC
+  rcpputils
   rclcpp
   vision_msgs
   rviz_common
@@ -102,6 +103,7 @@ ament_export_include_directories("include/${PROJECT_NAME}")
 ament_export_targets(${PROJECT_NAME} HAS_LIBRARY_TARGET)
 
 ament_export_dependencies(
+  rcpputils
   rclcpp
   vision_msgs
   rviz_common

--- a/vision_msgs_rviz_plugins/include/vision_msgs_rviz_plugins/bounding_box_3d_common.hpp
+++ b/vision_msgs_rviz_plugins/include/vision_msgs_rviz_plugins/bounding_box_3d_common.hpp
@@ -15,7 +15,6 @@
 #ifndef VISION_MSGS_RVIZ_PLUGINS__BOUNDING_BOX_3D_COMMON_HPP_
 #define VISION_MSGS_RVIZ_PLUGINS__BOUNDING_BOX_3D_COMMON_HPP_
 
-#include <QWidget>
 #include <memory>
 #include <string>
 #include <map>

--- a/vision_msgs_rviz_plugins/include/vision_msgs_rviz_plugins/detection_3d_common.hpp
+++ b/vision_msgs_rviz_plugins/include/vision_msgs_rviz_plugins/detection_3d_common.hpp
@@ -15,7 +15,6 @@
 #ifndef VISION_MSGS_RVIZ_PLUGINS__DETECTION_3D_COMMON_HPP_
 #define VISION_MSGS_RVIZ_PLUGINS__DETECTION_3D_COMMON_HPP_
 
-#include <QWidget>
 #include <yaml-cpp/yaml.h>
 
 #include <memory>
@@ -26,6 +25,7 @@
 #include <iomanip>
 #include <unordered_map>
 
+#include <rcpputils/filesystem_helper.hpp>
 #include <rviz_common/display.hpp>
 #include <rviz_common/properties/bool_property.hpp>
 #include <rviz_common/properties/float_property.hpp>


### PR DESCRIPTION
Besides the _rcpputils::fs_ problem there was a problem with the QT Meta-Object Compiler on the common headers that is also fixed with the commit:   
For testing I used the docker images _ros:rolling-ros-core-jammy_, _ros:humble-ros-core-jammy_, and _ros:foxy-ros-core-focal_ and built the package using: `. /opt/ros/$ROS_DISTRO/setup.sh && PYTHONIOENCODING=utf_8 PYTHONUNBUFFERED=1 colcon build --build-base build_isolated --install-base install_isolated --test-result-base test_results --event-handlers console_cohesion+ --cmake-args -DBUILD_TESTING=0` as it is apparently executed in the [jenkins build job](https://build.ros2.org/job/Fdev__vision_msgs__ubuntu_focal_amd64/18/consoleFull#console-section-12)   