### PR TITLE
Validate BoundingBox3D message

### DIFF
--- a/vision_msgs_rviz_plugins/include/vision_msgs_rviz_plugins/bounding_box_3d_common.hpp
+++ b/vision_msgs_rviz_plugins/include/vision_msgs_rviz_plugins/bounding_box_3d_common.hpp
@@ -90,11 +90,11 @@ protected:
       marker->scale.x = 1e-4;
     else
       marker->scale.x = static_cast<double>(box.size.x);
-    if (box.size.y == 0.0)
+    if (box.size.y < 1e-4)
       marker->scale.y = 1e-4;
     else
       marker->scale.y = static_cast<double>(box.size.y);
-    if (box.size.z == 0.0)
+    if (box.size.z < 1e-4)
       marker->scale.z = 1e-4;
     else
       marker->scale.z = static_cast<double>(box.size.z);

--- a/vision_msgs_rviz_plugins/include/vision_msgs_rviz_plugins/bounding_box_3d_common.hpp
+++ b/vision_msgs_rviz_plugins/include/vision_msgs_rviz_plugins/bounding_box_3d_common.hpp
@@ -86,28 +86,19 @@ protected:
     // Some systems can return BoundingBox3D messages with one dimension set to zero.
     // (for example Isaac Sim can have a mesh that is only a plane)
     // This is not supported by Rviz markers so set the scale to a small value if this happens.
-    if (box.size.x < 1e-4)
-    {
+    if (box.size.x < 1e-4) {
       marker->scale.x = 1e-4;
-    }
-    else
-    {
+    } else {
       marker->scale.x = static_cast<double>(box.size.x);
     }
-    if (box.size.y < 1e-4)
-    {
+    if (box.size.y < 1e-4) {
       marker->scale.y = 1e-4;
-    }
-    else
-    {
+    } else {
       marker->scale.y = static_cast<double>(box.size.y);
     }
-    if (box.size.z < 1e-4)
-    {
+    if (box.size.z < 1e-4) {
       marker->scale.z = 1e-4;
-    }
-    else
-    {
+    } else {
       marker->scale.z = static_cast<double>(box.size.z);
     }
 

--- a/vision_msgs_rviz_plugins/include/vision_msgs_rviz_plugins/bounding_box_3d_common.hpp
+++ b/vision_msgs_rviz_plugins/include/vision_msgs_rviz_plugins/bounding_box_3d_common.hpp
@@ -57,7 +57,7 @@ protected:
   std::vector<BillboardLinePtr> edges_;
 
   visualization_msgs::msg::Marker::SharedPtr get_marker(
-    const vision_msgs::msg::BoundingBox3D & box) const
+    const vision_msgs::msg::BoundingBox3D & box)
   {
     auto marker = std::make_shared<Marker>();
 
@@ -71,9 +71,33 @@ protected:
     marker->pose.orientation.y = static_cast<double>(box.center.orientation.y);
     marker->pose.orientation.z = static_cast<double>(box.center.orientation.z);
     marker->pose.orientation.w = static_cast<double>(box.center.orientation.w);
-    marker->scale.x = static_cast<double>(box.size.x);
-    marker->scale.y = static_cast<double>(box.size.y);
-    marker->scale.z = static_cast<double>(box.size.z);
+
+    if (box.size.x < 0.0 || box.size.y < 0.0 || box.size.z < 0.0)
+    {
+      std::ostringstream oss;
+        oss << "Error received BoundingBox3D message with size value less than zero.\n";
+        oss << "X: " << box.size.x << " Y: " << box.size.y << " Z: " << box.size.z;
+        RVIZ_COMMON_LOG_ERROR_STREAM(oss.str());
+        this->setStatus(
+          rviz_common::properties::StatusProperty::Error, "Scale", QString::fromStdString(
+            oss.str()));
+    }
+
+    // Some systems can return BoundingBox3D messages with one dimension set to zero.
+    // (for example Isaac Sim can have a mesh that is only a plane)
+    // This is not supported by Rviz markers so set the scale to a small value if this happens.
+    if (box.size.x < 1e-4)
+      marker->scale.x = 1e-4;
+    else
+      marker->scale.x = static_cast<double>(box.size.x);
+    if (box.size.y == 0.0)
+      marker->scale.y = 1e-4;
+    else
+      marker->scale.y = static_cast<double>(box.size.y);
+    if (box.size.z == 0.0)
+      marker->scale.z = 1e-4;
+    else
+      marker->scale.z = static_cast<double>(box.size.z);
 
     return marker;
   }

--- a/vision_msgs_rviz_plugins/include/vision_msgs_rviz_plugins/bounding_box_3d_common.hpp
+++ b/vision_msgs_rviz_plugins/include/vision_msgs_rviz_plugins/bounding_box_3d_common.hpp
@@ -72,15 +72,14 @@ protected:
     marker->pose.orientation.z = static_cast<double>(box.center.orientation.z);
     marker->pose.orientation.w = static_cast<double>(box.center.orientation.w);
 
-    if (box.size.x < 0.0 || box.size.y < 0.0 || box.size.z < 0.0)
-    {
+    if (box.size.x < 0.0 || box.size.y < 0.0 || box.size.z < 0.0) {
       std::ostringstream oss;
-        oss << "Error received BoundingBox3D message with size value less than zero.\n";
-        oss << "X: " << box.size.x << " Y: " << box.size.y << " Z: " << box.size.z;
-        RVIZ_COMMON_LOG_ERROR_STREAM(oss.str());
-        this->setStatus(
-          rviz_common::properties::StatusProperty::Error, "Scale", QString::fromStdString(
-            oss.str()));
+      oss << "Error received BoundingBox3D message with size value less than zero.\n";
+      oss << "X: " << box.size.x << " Y: " << box.size.y << " Z: " << box.size.z;
+      RVIZ_COMMON_LOG_ERROR_STREAM(oss.str());
+      this->setStatus(
+        rviz_common::properties::StatusProperty::Error, "Scale", QString::fromStdString(
+          oss.str()));
     }
 
     // Some systems can return BoundingBox3D messages with one dimension set to zero.

--- a/vision_msgs_rviz_plugins/include/vision_msgs_rviz_plugins/bounding_box_3d_common.hpp
+++ b/vision_msgs_rviz_plugins/include/vision_msgs_rviz_plugins/bounding_box_3d_common.hpp
@@ -87,17 +87,29 @@ protected:
     // (for example Isaac Sim can have a mesh that is only a plane)
     // This is not supported by Rviz markers so set the scale to a small value if this happens.
     if (box.size.x < 1e-4)
+    {
       marker->scale.x = 1e-4;
+    }
     else
+    {
       marker->scale.x = static_cast<double>(box.size.x);
+    }
     if (box.size.y < 1e-4)
+    {
       marker->scale.y = 1e-4;
+    }
     else
+    {
       marker->scale.y = static_cast<double>(box.size.y);
+    }
     if (box.size.z < 1e-4)
+    {
       marker->scale.z = 1e-4;
+    }
     else
+    {
       marker->scale.z = static_cast<double>(box.size.z);
+    }
 
     return marker;
   }

--- a/vision_msgs_rviz_plugins/include/vision_msgs_rviz_plugins/detection_3d_common.hpp
+++ b/vision_msgs_rviz_plugins/include/vision_msgs_rviz_plugins/detection_3d_common.hpp
@@ -88,15 +88,14 @@ protected:
     marker->pose.orientation.z = static_cast<double>(box.center.orientation.z);
     marker->pose.orientation.w = static_cast<double>(box.center.orientation.w);
 
-    if (box.size.x < 0.0 || box.size.y < 0.0 || box.size.z < 0.0)
-    {
+    if (box.size.x < 0.0 || box.size.y < 0.0 || box.size.z < 0.0) {
       std::ostringstream oss;
-        oss << "Error received BoundingBox3D message with size value less than zero.\n";
-        oss << "X: " << box.size.x << " Y: " << box.size.y << " Z: " << box.size.z;
-        RVIZ_COMMON_LOG_ERROR_STREAM(oss.str());
-        this->setStatus(
-          rviz_common::properties::StatusProperty::Error, "Scale", QString::fromStdString(
-            oss.str()));
+      oss << "Error received BoundingBox3D message with size value less than zero.\n";
+      oss << "X: " << box.size.x << " Y: " << box.size.y << " Z: " << box.size.z;
+      RVIZ_COMMON_LOG_ERROR_STREAM(oss.str());
+      this->setStatus(
+        rviz_common::properties::StatusProperty::Error, "Scale", QString::fromStdString(
+          oss.str()));
     }
 
     // Some systems can return BoundingBox3D messages with one dimension set to zero.

--- a/vision_msgs_rviz_plugins/include/vision_msgs_rviz_plugins/detection_3d_common.hpp
+++ b/vision_msgs_rviz_plugins/include/vision_msgs_rviz_plugins/detection_3d_common.hpp
@@ -102,28 +102,19 @@ protected:
     // Some systems can return BoundingBox3D messages with one dimension set to zero.
     // (for example Isaac Sim can have a mesh that is only a plane)
     // This is not supported by Rviz markers so set the scale to a small value if this happens.
-    if (box.size.x < 1e-4)
-    {
+    if (box.size.x < 1e-4) {
       marker->scale.x = 1e-4;
-    }
-    else
-    {
+    } else {
       marker->scale.x = static_cast<double>(box.size.x);
     }
-    if (box.size.y < 1e-4)
-    {
+    if (box.size.y < 1e-4) {
       marker->scale.y = 1e-4;
-    }
-    else
-    {
+    } else {
       marker->scale.y = static_cast<double>(box.size.y);
     }
-    if (box.size.z < 1e-4)
-    {
+    if (box.size.z < 1e-4) {
       marker->scale.z = 1e-4;
-    }
-    else
-    {
+    } else {
       marker->scale.z = static_cast<double>(box.size.z);
     }
 

--- a/vision_msgs_rviz_plugins/include/vision_msgs_rviz_plugins/detection_3d_common.hpp
+++ b/vision_msgs_rviz_plugins/include/vision_msgs_rviz_plugins/detection_3d_common.hpp
@@ -87,7 +87,7 @@ protected:
     marker->pose.orientation.y = static_cast<double>(box.center.orientation.y);
     marker->pose.orientation.z = static_cast<double>(box.center.orientation.z);
     marker->pose.orientation.w = static_cast<double>(box.center.orientation.w);
-    
+
     if (box.size.x < 0.0 || box.size.y < 0.0 || box.size.z < 0.0)
     {
       std::ostringstream oss;
@@ -103,17 +103,29 @@ protected:
     // (for example Isaac Sim can have a mesh that is only a plane)
     // This is not supported by Rviz markers so set the scale to a small value if this happens.
     if (box.size.x < 1e-4)
+    {
       marker->scale.x = 1e-4;
+    }
     else
+    {
       marker->scale.x = static_cast<double>(box.size.x);
+    }
     if (box.size.y < 1e-4)
+    {
       marker->scale.y = 1e-4;
+    }
     else
+    {
       marker->scale.y = static_cast<double>(box.size.y);
+    }
     if (box.size.z < 1e-4)
+    {
       marker->scale.z = 1e-4;
+    }
     else
+    {
       marker->scale.z = static_cast<double>(box.size.z);
+    }
 
     return marker;
   }

--- a/vision_msgs_rviz_plugins/include/vision_msgs_rviz_plugins/detection_3d_common.hpp
+++ b/vision_msgs_rviz_plugins/include/vision_msgs_rviz_plugins/detection_3d_common.hpp
@@ -106,11 +106,11 @@ protected:
       marker->scale.x = 1e-4;
     else
       marker->scale.x = static_cast<double>(box.size.x);
-    if (box.size.y == 0.0)
+    if (box.size.y < 1e-4)
       marker->scale.y = 1e-4;
     else
       marker->scale.y = static_cast<double>(box.size.y);
-    if (box.size.z == 0.0)
+    if (box.size.z < 1e-4)
       marker->scale.z = 1e-4;
     else
       marker->scale.z = static_cast<double>(box.size.z);

--- a/vision_msgs_rviz_plugins/include/vision_msgs_rviz_plugins/detection_3d_common.hpp
+++ b/vision_msgs_rviz_plugins/include/vision_msgs_rviz_plugins/detection_3d_common.hpp
@@ -73,7 +73,7 @@ protected:
     {"motorcycle", QColor(230, 230, 250)}};
 
   visualization_msgs::msg::Marker::SharedPtr get_marker(
-    const vision_msgs::msg::BoundingBox3D & box) const
+    const vision_msgs::msg::BoundingBox3D & box)
   {
     auto marker = std::make_shared<Marker>();
 
@@ -87,9 +87,33 @@ protected:
     marker->pose.orientation.y = static_cast<double>(box.center.orientation.y);
     marker->pose.orientation.z = static_cast<double>(box.center.orientation.z);
     marker->pose.orientation.w = static_cast<double>(box.center.orientation.w);
-    marker->scale.x = static_cast<double>(box.size.x);
-    marker->scale.y = static_cast<double>(box.size.y);
-    marker->scale.z = static_cast<double>(box.size.z);
+    
+    if (box.size.x < 0.0 || box.size.y < 0.0 || box.size.z < 0.0)
+    {
+      std::ostringstream oss;
+        oss << "Error received BoundingBox3D message with size value less than zero.\n";
+        oss << "X: " << box.size.x << " Y: " << box.size.y << " Z: " << box.size.z;
+        RVIZ_COMMON_LOG_ERROR_STREAM(oss.str());
+        this->setStatus(
+          rviz_common::properties::StatusProperty::Error, "Scale", QString::fromStdString(
+            oss.str()));
+    }
+
+    // Some systems can return BoundingBox3D messages with one dimension set to zero.
+    // (for example Isaac Sim can have a mesh that is only a plane)
+    // This is not supported by Rviz markers so set the scale to a small value if this happens.
+    if (box.size.x < 1e-4)
+      marker->scale.x = 1e-4;
+    else
+      marker->scale.x = static_cast<double>(box.size.x);
+    if (box.size.y == 0.0)
+      marker->scale.y = 1e-4;
+    else
+      marker->scale.y = static_cast<double>(box.size.y);
+    if (box.size.z == 0.0)
+      marker->scale.z = 1e-4;
+    else
+      marker->scale.z = static_cast<double>(box.size.z);
 
     return marker;
   }


### PR DESCRIPTION
I have been working on testing the ground truth system of Isaac sim and have found some [issues](https://forums.developer.nvidia.com/t/ros-2-bridge-camera-helper-issues/244072) with their publishers of vision_msgs data. They are working on improving this tool, but while talking with their engineers they pointed me to a case where one dimension of the BoundingBox3D message can be set to zero. That is if a flat plane mesh is in the scene, the 3d bbox will have zero thickness. In this PR I have submitted a suggestion on how the Rviz plugin can support this.