### PR TITLE
Utilize vision_msgs/Point2D in BoundingBox2D

### DIFF
--- a/vision_msgs/include/vision_msgs/create_aabb.hpp
+++ b/vision_msgs/include/vision_msgs/create_aabb.hpp
@@ -35,8 +35,8 @@ static inline msg::BoundingBox2D createAABB2D(
 
   bbox.center.position.x = left + width / 2.0;
   bbox.center.position.y = top + height / 2.0;
-  bbox.size_x = width;
-  bbox.size_y = height;
+  bbox.size.x = width;
+  bbox.size.y = height;
 
   return bbox;
 }

--- a/vision_msgs/msg/BoundingBox2D.msg
+++ b/vision_msgs/msg/BoundingBox2D.msg
@@ -9,5 +9,4 @@ vision_msgs/Pose2D center
 
 # The total size (in pixels) of the bounding box surrounding the object relative
 #   to the pose of its center.
-float64 size_x
-float64 size_y
+vision_msgs/Point2D size

--- a/vision_msgs/test/main.cpp
+++ b/vision_msgs/test/main.cpp
@@ -23,8 +23,8 @@ TEST(vision_msgs, CreateAABB2D)
   vision_msgs::msg::BoundingBox2D bbox = vision_msgs::createAABB2D(1, 2, 3, 4);
   EXPECT_FLOAT_EQ(bbox.center.position.x, 2.5);  // 1 + 3/2
   EXPECT_FLOAT_EQ(bbox.center.position.y, 4);    // 2 + 4/2
-  EXPECT_EQ(bbox.size_x, 3);
-  EXPECT_EQ(bbox.size_y, 4);
+  EXPECT_EQ(bbox.size.x, 3);
+  EXPECT_EQ(bbox.size.y, 4);
   EXPECT_EQ(bbox.center.theta, 0);
 }
 


### PR DESCRIPTION
I'd like to use geometry_msgs/Point2D(?) or vision_msgs/Size2D(?) hopefully if it exists.
(I know there does not exist)

But, I think this is more intutive and matched a consistency with [BoundingBox3D](https://github.com/ros-perception/vision_msgs/blob/ros2/vision_msgs/msg/BoundingBox3D.msg),