### PR TITLE
Clear rviz plugins stale markers

### DIFF
--- a/vision_msgs_rviz_plugins/include/vision_msgs_rviz_plugins/bounding_box_3d_common.hpp
+++ b/vision_msgs_rviz_plugins/include/vision_msgs_rviz_plugins/bounding_box_3d_common.hpp
@@ -107,6 +107,7 @@ protected:
   void showBoxes(const BoundingBox3DArray::ConstSharedPtr & msg)
   {
     edges_.clear();
+    m_marker_common->clearMarkers();
 
     for (size_t idx = 0U; idx < msg->boxes.size(); idx++) {
       const auto marker_ptr = get_marker(msg->boxes[idx]);
@@ -125,6 +126,7 @@ protected:
   void showBoxes(const BoundingBox3D::ConstSharedPtr & msg)
   {
     edges_.clear();
+    m_marker_common->clearMarkers();
 
     const auto marker_ptr = get_marker(*msg);
     marker_ptr->header.frame_id = qPrintable(this->fixed_frame_);

--- a/vision_msgs_rviz_plugins/include/vision_msgs_rviz_plugins/detection_3d_common.hpp
+++ b/vision_msgs_rviz_plugins/include/vision_msgs_rviz_plugins/detection_3d_common.hpp
@@ -146,6 +146,7 @@ protected:
     const bool show_score)
   {
     edges_.clear();
+    m_marker_common->clearMarkers();
     ClearScores(show_score);
 
     for (size_t idx = 0U; idx < msg->detections.size(); idx++) {
@@ -181,6 +182,7 @@ protected:
   void showBoxes(const vision_msgs::msg::Detection3D::ConstSharedPtr & msg, const bool show_score)
   {
     edges_.clear();
+    m_marker_common->clearMarkers();
     ClearScores(show_score);
 
     const auto marker_ptr = get_marker(msg->bbox);


### PR DESCRIPTION
From my own experience and as reported in https://github.com/NovoG93/vision_msgs_rviz_plugins/issues/4 some visualization markers would sometimes persist and go stale (this seems to be when new boxes size is less than the older boxes size, the excess boxes won't be modified and will be left around until something or nothing happens).

After the latest changes I no longer see the issue (Tested with live Detection3DArray). If a node stops publishing detections/bounding boxes, the markers will also disappear according to the marker lifetime.