### PR TITLE
Replace ament_target_dependencies with target_link_libraries

### DIFF
--- a/vision_msgs/CMakeLists.txt
+++ b/vision_msgs/CMakeLists.txt
@@ -50,9 +50,9 @@ if(BUILD_TESTING)
 
   ament_add_gtest(vision_msgs_test test/main.cpp)
   add_dependencies(vision_msgs_test ${PROJECT_NAME})
-  ament_target_dependencies(vision_msgs_test
-    geometry_msgs
-    std_msgs
+  target_link_libraries(vision_msgs_test
+    ${geometry_msgs_TARGETS}
+    ${std_msgs_TARGETS}
   )
   # TODO(sloretz) rosidl_generate_interfaces() should make using generated messages in same project simpler
   target_include_directories(vision_msgs_test PUBLIC

--- a/vision_msgs_rviz_plugins/CMakeLists.txt
+++ b/vision_msgs_rviz_plugins/CMakeLists.txt
@@ -82,15 +82,15 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
 target_compile_definitions(${PROJECT_NAME} PRIVATE "RVIZ_DEFAULT_PLUGINS_BUILDING_LIBRARY")
 
 
-ament_target_dependencies(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME}
   PUBLIC
-  rcpputils
-  rclcpp
-  vision_msgs
-  rviz_common
-  rviz_rendering
-  rviz_default_plugins
-  yaml_cpp_vendor
+  rcpputils::rcpputils
+  rclcpp::rclcpp
+  ${vision_msgs_TARGETS}
+  rviz_common::rviz_common
+  rviz_rendering::rviz_rendering
+  rviz_default_plugins::rviz_default_plugins
+  yaml-cpp::yaml-cpp
 )
 
 # Export the plugin to be imported by rviz2


### PR DESCRIPTION
`ament_target_dependencies` is deprecated on `kilted` and removed in `rolling`,  It will require a new release on `rolling`.


Debs are broken https://build.ros2.org/view/Rbin_uN64/job/Rbin_uN64__vision_msgs_rviz_plugins__ubuntu_noble_amd64__binary/