### PR TITLE
rclcpp::filesystem deprecation

### DIFF
--- a/vision_msgs_rviz_plugins/CMakeLists.txt
+++ b/vision_msgs_rviz_plugins/CMakeLists.txt
@@ -22,7 +22,6 @@ find_package(yaml_cpp_vendor REQUIRED)
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_python REQUIRED)
 
-find_package(rcpputils)
 find_package(rclcpp REQUIRED)
 find_package(rclpy REQUIRED)
 
@@ -84,7 +83,6 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE "RVIZ_DEFAULT_PLUGINS_BUILDIN
 
 ament_target_dependencies(${PROJECT_NAME}
   PUBLIC
-  rcpputils
   rclcpp
   vision_msgs
   rviz_common
@@ -103,7 +101,6 @@ ament_export_include_directories("include/${PROJECT_NAME}")
 ament_export_targets(${PROJECT_NAME} HAS_LIBRARY_TARGET)
 
 ament_export_dependencies(
-  rcpputils
   rclcpp
   vision_msgs
   rviz_common

--- a/vision_msgs_rviz_plugins/include/vision_msgs_rviz_plugins/detection_3d_common.hpp
+++ b/vision_msgs_rviz_plugins/include/vision_msgs_rviz_plugins/detection_3d_common.hpp
@@ -17,15 +17,15 @@
 
 #include <yaml-cpp/yaml.h>
 
+#include <algorithm>
+#include <filesystem>
+#include <iomanip>
+#include <map>
 #include <memory>
 #include <string>
-#include <map>
-#include <algorithm>
-#include <vector>
-#include <iomanip>
 #include <unordered_map>
+#include <vector>
 
-#include <rcpputils/filesystem_helper.hpp>
 #include <rviz_common/display.hpp>
 #include <rviz_common/properties/bool_property.hpp>
 #include <rviz_common/properties/float_property.hpp>
@@ -513,7 +513,7 @@ protected:
   {
     std::ostringstream oss;
     const std::string tmp_path = string_property_->getStdString();
-    if (rcpputils::fs::exists(tmp_path)) {
+    if (std::filesystem::exists(tmp_path)) {
       color_config_path_ = tmp_path;
       std::ifstream fin(color_config_path_);
       YAML::Node config = YAML::Load(fin);


### PR DESCRIPTION
Probably requires diferent branches for `humble` and `jazzy`. 